### PR TITLE
Improve spectrum analyzer and CSS segregation

### DIFF
--- a/.project/todo.md
+++ b/.project/todo.md
@@ -1,8 +1,13 @@
 - [x] 1. Add a volume control to the metronome page & link volume controls across all pages.
 - [x] 2. In the metronome can you add a selection of beats per bar, and highlight beat 1 of each bar with a slightly different sound.
-- [] 3. On tuner rather than a pendulum can you do a vertical bar that moves left and right along a spectrum.
-- [] 4. on tuner allow option to play the note on the page as well to help with feel of matching the note.
-- [] 5. metronome: invert the pendulum so that base is fixed postion and top swings.
+- [x] 3. On tuner rather than a pendulum can you do a vertical bar that moves left and right along a spectrum.
+- [x] 4. on tuner allow option to play the note on the page as well to help with feel of matching the note.
+- [x] 5. metronome: invert the pendulum so that base is fixed postion and top swings.
 - [] 6. work on synth-pads to make them better.
-- [] 7. x-axis on spectrum analyser should be somethings I can expand to see larger dynamic range.
+- [x] 7. x-axis on spectrum analyser should be somethings I can expand to see larger dynamic range (on all instances of the spectrum analyser, and these should be sync'd to each other).
 - [] 8. add option to remove "room noise" from spectrum analyser for the tuner.
+- [] 9. more granular bars on spectrum analyser (all instances)
+- [x] 10. completely remove the checkbox for prod mode.
+- [x] 11. tuner bar should move slower/have a range that it wider to allow it to move slower with the sound - it should include markers on it to indicate range that is "good enough" for in tune as well as the perfect point (exact frequency match).
+- [x] BUG001: related to todo item 4 - when played the note should play continually until stopped.
+- [x] BUG002: related to item 7, you have done an option for frequency range (x-axis), but what I wanted was power range (y-axis) - sorry it was my mistake in the description.

--- a/.project/todo.md
+++ b/.project/todo.md
@@ -4,10 +4,12 @@
 - [x] 4. on tuner allow option to play the note on the page as well to help with feel of matching the note.
 - [x] 5. metronome: invert the pendulum so that base is fixed postion and top swings.
 - [] 6. work on synth-pads to make them better.
-- [x] 7. x-axis on spectrum analyser should be somethings I can expand to see larger dynamic range (on all instances of the spectrum analyser, and these should be sync'd to each other).
+- [x] 7. y-axis on spectrum analyser should be somethings I can expand to see larger dynamic range (on all instances of the spectrum analyser, and these should be sync'd to each other).
 - [] 8. add option to remove "room noise" from spectrum analyser for the tuner.
 - [] 9. more granular bars on spectrum analyser (all instances)
 - [x] 10. completely remove the checkbox for prod mode.
 - [x] 11. tuner bar should move slower/have a range that it wider to allow it to move slower with the sound - it should include markers on it to indicate range that is "good enough" for in tune as well as the perfect point (exact frequency match).
 - [x] BUG001: related to todo item 4 - when played the note should play continually until stopped.
 - [x] BUG002: related to item 7, you have done an option for frequency range (x-axis), but what I wanted was power range (y-axis) - sorry it was my mistake in the description.
+- [] 12. If user is trying to play note and run tuner at the same time then the page should alternate quickly between playing the note and running the tuner - preferable alternate really fast to avoid the feedback loop and also to make it imperceptable to human that it is switching (avoiding feedback is more important)
+- [] BUG003. related to BUG002 - when I select 80dB I don't see any y-axis ticks.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,17 +1,21 @@
 # Signal Generator
 
 ## Overview
-Single-file web app (`index.html`) — no build system, tests, or CI.
+Web app with separate source files — no build system, tests, or CI.
 
 ## Development
 - `npm run dev` — Start dev server on port 3000 (serves `index.html`)
 - Open `index.html` directly in a browser to test
-- All logic is embedded in the file — HTML, CSS, and JS in one document
+- Source files are separated by language:
+  - `index.html` — HTML structure
+  - `styles.css` — CSS styles
+  - `javascript/*.js` — JavaScript logic
 - No external dependencies or CDN resources
 
 ## Coding Standards
 - Always add comments to code explaining what it does
 - Comments should be clear and helpful for future maintainers
+- Each language must be kept in separate source files (HTML in .html, CSS in .css, JS in .js)
 
 ## GitHub Codespace
 - Port 3000 is auto-forwarded and opens preview

--- a/README.md
+++ b/README.md
@@ -1,6 +1,56 @@
-# Signal Generator
-Signal generator and analyser — sum of sine waves, time/frequency domain visualisation, audio recording
+# Audio Tools — Signal Generator
 
-## Test Environment
-Done in GitHub Codespace
-- `npm run dev` — Start dev server on port 3000 (serves `index.html`)
+A web-based audio tool with signal generation, recording, tuning, metronome, and synth pads. No build system required — pure HTML, CSS, and JavaScript.
+
+## Features
+
+- **Signal Generator** — Create custom waveforms using multiple frequency components with real-time visualization
+- **Audio Recorder** — Record audio with live monitoring and spectrum analysis
+- **Tuner** — Guitar/bass tuner with visual feedback, target note selection, and alternating reference tone
+- **Metronome** — Adjustable tempo (40-240 BPM) with visual pendulum and LED level display
+- **Synth Pads** — Playable synthesizer pads with multiple waveforms
+
+## Quick Start
+
+### GitHub Codespace
+Port 3000 is auto-forwarded and opens a preview. The dev server auto-starts via `postStartCommand` in `devcontainer.json`.
+
+### Local Development
+```bash
+npm run dev    # Starts dev server on port 3000
+```
+
+Or open `index.html` directly in a browser (no server required for basic functionality).
+
+## File Structure
+
+```
+signal-generator/
+├── index.html              # HTML structure
+├── styles.css              # CSS styles
+├── javascript/
+│   ├── drawing.js         # Shared canvas drawing functions
+│   ├── main.js            # Main initialization and tab switching
+│   ├── presets.js         # Signal generator (page 1) logic
+│   ├── recorder.js        # Audio recorder (page 2) logic
+│   ├── tuner.js           # Tuner (page 3) logic
+│   ├── metronome.js       # Metronome (page 4) logic
+│   ├── pads.js            # Synth pads (page 5) logic
+│   └── shared.js          # Shared state and utilities
+├── AGENTS.md              # Instructions for AI coding agents
+└── README.md
+```
+
+## Key Technical Details
+
+- **Web Audio API** — Uses `AudioContext`, `OscillatorNode`, `AnalyserNode`, `MediaRecorder`
+- **Canvas Visualizations** — High-DPI support via `devicePixelRatio`
+- **Spectrum Analyzer** — Logarithmic frequency scale (10 Hz – 32 kHz), adjustable min power (-10 to -80 dB)
+- **Waveforms** — Sine, square, sawtooth, triangle + white/pink/brown noise
+- **Microphone Access** — Recording and tuner require microphone permission
+
+## Coding Standards
+
+- Each language kept in separate source files (HTML in `.html`, CSS in `.css`, JS in `.js`)
+- Comments explain what code does for future maintainers
+- No external dependencies or CDN resources

--- a/index.html
+++ b/index.html
@@ -227,25 +227,6 @@
     <input type="range" id="master-volume" min="0" max="1" step="0.01" value="0.8" oninput="onMasterVolumeChange()"/>
     <span id="master-vol-label">80%</span>
   </div>
-  <div class="flex-row" style="justify-content:center;margin-top:6px;gap:8px;font-size:.75rem;color:var(--muted);">
-    <label style="display:flex;align-items:center;gap:4px;cursor:pointer;">
-      Spectrum Range:
-      <select class="styled" id="spectrum-range" onchange="onSpectrumRangeChange()" style="font-size:.75rem;padding:2px 4px;">
-        <option value="8000">8 kHz</option>
-        <option value="16000">16 kHz</option>
-        <option value="32000" selected>32 kHz</option>
-      </select>
-    </label>
-    <label style="display:flex;align-items:center;gap:4px;cursor:pointer;">
-      Min Power:
-      <select class="styled" id="power-range" onchange="onPowerRangeChange()" style="font-size:.75rem;padding:2px 4px;">
-        <option value="0">0 dB (full)</option>
-        <option value="40" selected>40 dB</option>
-        <option value="60">60 dB</option>
-        <option value="80">80 dB</option>
-      </select>
-    </label>
-  </div>
 </header>
 
 <!-- ═══ TAB BAR ═══ -->
@@ -359,7 +340,14 @@
           <canvas id="p1-canvas-time"></canvas>
         </div>
         <div class="graph-wrap">
-          <h3>Spectrum Analyser <span class="tag tag-gen">Generated</span> <span style="font-size:.65rem;color:var(--muted);">0 – 32 kHz</span></h3>
+          <h3>Spectrum Analyser <span class="tag tag-gen">Generated</span> <span style="font-size:.65rem;color:var(--muted);">0 – 32 kHz</span>
+            <select class="styled" id="power-range-p1-canvas-freq" onchange="onPowerRangeChange('p1-canvas-freq')" style="font-size:.7rem;padding:2px 4px;margin-left:8px;">
+              <option value="10">-10 dB</option>
+              <option value="20">-20 dB</option>
+              <option value="40" selected>-40 dB</option>
+              <option value="80">-80 dB</option>
+            </select>
+          </h3>
           <canvas id="p1-canvas-freq"></canvas>
         </div>
       </div>
@@ -472,7 +460,14 @@
         </div>
 
         <div class="graph-wrap" style="position:relative;">
-          <h3>Spectrum Analyser <span class="tag tag-rec" id="rec-freq-tag">Recorded</span> <span style="font-size:.65rem;color:var(--muted);">0 – 32 kHz</span></h3>
+          <h3>Spectrum Analyser <span class="tag tag-rec" id="rec-freq-tag">Recorded</span> <span style="font-size:.65rem;color:var(--muted);">0 – 32 kHz</span>
+            <select class="styled" id="power-range-rec-canvas-freq" onchange="onPowerRangeChange('rec-canvas-freq')" style="font-size:.7rem;padding:2px 4px;margin-left:8px;">
+              <option value="10">-10 dB</option>
+              <option value="20">-20 dB</option>
+              <option value="40" selected>-40 dB</option>
+              <option value="80">-80 dB</option>
+            </select>
+          </h3>
           <canvas id="rec-canvas-freq"></canvas>
           <div class="no-data" id="no-rec-freq">Record audio to see spectrum</div>
         </div>
@@ -558,7 +553,14 @@
           <div class="no-data" id="tuner-no-time">Start tuner to see waveform</div>
         </div>
         <div class="graph-wrap">
-          <h3>Spectrum Analyser <span class="tag tag-live" id="tuner-freq-tag" style="display:none;">Live</span></h3>
+          <h3>Spectrum Analyser <span class="tag tag-live" id="tuner-freq-tag" style="display:none;">Live</span>
+            <select class="styled" id="power-range-tuner-canvas-freq" onchange="onPowerRangeChange('tuner-canvas-freq')" style="font-size:.7rem;padding:2px 4px;margin-left:8px;">
+              <option value="10">-10 dB</option>
+              <option value="20">-20 dB</option>
+              <option value="40" selected>-40 dB</option>
+              <option value="80">-80 dB</option>
+            </select>
+          </h3>
           <canvas id="tuner-canvas-freq"></canvas>
           <div class="no-data" id="tuner-no-freq">Start tuner to see spectrum</div>
         </div>

--- a/index.html
+++ b/index.html
@@ -3,226 +3,14 @@
 <head>
   <meta charset="UTF-8"/>
   <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-  <title>Audio Tools 🎛️</title>
-  <link rel="icon" href="icons/favicon.ico" type="image/x-icon"/>
-  <style>
-    *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
-    :root {
-      --bg: #0f1117; --card: #1a1d27; --card2: #21253a; --border: #2e3250;
-      --accent: #6c8aff; --accent2: #a78bfa; --green: #34d399; --red: #f87171;
-      --yellow: #fbbf24; --text: #e2e8f0; --muted: #64748b;
-    }
-    body { background: var(--bg); color: var(--text); font-family: 'Segoe UI', system-ui, sans-serif; min-height: 100vh; padding: 0 0 40px; }
-
-    /* Tooltip styles */
-    [title] { position: relative; }
-    [title]:hover::after {
-      content: attr(title);
-      position: absolute;
-      bottom: 100%;
-      left: 50%;
-      transform: translateX(-50%);
-      background: var(--card2);
-      color: var(--text);
-      padding: 4px 8px;
-      border-radius: 4px;
-      font-size: 0.7rem;
-      white-space: nowrap;
-      z-index: 100;
-      pointer-events: none;
-      margin-bottom: 4px;
-    }
-
-    /* Card info tooltip */
-    .card[data-info] { position: relative; }
-    .card[data-info]:hover::after {
-      content: attr(data-info);
-      position: absolute;
-      top: -8px;
-      right: -8px;
-      background: var(--card2);
-      color: var(--text);
-      padding: 8px 12px;
-      border-radius: 6px;
-      font-size: 0.7rem;
-      white-space: normal;
-      max-width: 250px;
-      z-index: 100;
-      pointer-events: none;
-      box-shadow: 0 4px 12px rgba(0,0,0,0.4);
-      border: 1px solid var(--border);
-    }
-
-    /* Info icon */
-    .info-icon {
-      display: inline-block;
-      font-size: 0.7rem;
-      color: var(--muted);
-      cursor: help;
-      margin-left: 4px;
-      font-weight: normal;
-    }
-    .info-icon:hover {
-      color: var(--accent);
-    }
-
-    /* Card h2 with info icon */
-    .card h2 { display: flex; align-items: center; }
-
-    /* ── Header ── */
-    header { text-align: center; padding: 24px 20px 0; }
-    header h1 { font-size: 1.8rem; font-weight: 800; background: linear-gradient(135deg, var(--accent), var(--accent2)); -webkit-background-clip: text; -webkit-text-fill-color: transparent; background-clip: text; }
-    header p { color: var(--muted); font-size: 0.85rem; margin-top: 4px; }
-
-    /* ── Tabs ── */
-    .tab-bar { display: flex; gap: 0; justify-content: center; margin: 20px 20px 0; border-bottom: 2px solid var(--border); }
-    .tab { padding: 10px 24px; font-size: 0.88rem; font-weight: 700; cursor: pointer; border: none; background: none; color: var(--muted); border-bottom: 3px solid transparent; margin-bottom: -2px; transition: color 0.2s, border-color 0.2s; }
-    .tab:hover { color: var(--text); }
-    .tab.active { color: var(--accent); border-bottom-color: var(--accent); }
-
-    /* ── Pages ── */
-    .page { display: none; padding: 20px; max-width: 1400px; margin: 0 auto; }
-    .page.active { display: block; }
-
-    /* ── Card ── */
-    .card { background: var(--card); border: 1px solid var(--border); border-radius: 16px; padding: 20px; }
-    .card + .card { margin-top: 16px; }
-    .card h2 { font-size: 0.75rem; font-weight: 700; text-transform: uppercase; letter-spacing: 0.1em; color: var(--accent); margin-bottom: 14px; }
-
-    /* ── Layout helpers ── */
-    .cols { display: grid; gap: 20px; }
-    .cols-2 { grid-template-columns: 1fr 1fr; }
-    .cols-left-right { grid-template-columns: 340px 1fr; }
-    @media(max-width:960px){ .cols-left-right,.cols-2 { grid-template-columns:1fr; } }
-    .flex-col { display:flex; flex-direction:column; gap:16px; }
-    .flex-row { display:flex; gap:10px; align-items:center; flex-wrap:wrap; }
-
-    /* ── Buttons ── */
-    .btn { padding: 10px 16px; border: none; border-radius: 12px; font-size: 0.87rem; font-weight: 700; cursor: pointer; transition: opacity .15s, transform .1s; }
-    .btn:active { transform: scale(.97); }
-    .btn:disabled { opacity: .38; cursor: default; }
-    .btn-primary  { background: linear-gradient(135deg, var(--accent), var(--accent2)); color: #fff; }
-    .btn-stop     { background: var(--card2); border: 1.5px solid var(--border); color: var(--text); }
-    .btn-rec      { background: linear-gradient(135deg, #ef4444, #f97316); color: #fff; }
-    .btn-green    { background: linear-gradient(135deg, #34d399, #059669); color: #fff; }
-    .btn-sm       { padding: 5px 12px; font-size: 0.78rem; border-radius: 8px; }
-    .btn-rec.recording { animation: pulse 1s infinite; }
-    @keyframes pulse { 0%,100%{opacity:1} 50%{opacity:.55} }
-
-    /* ── Preset buttons ── */
-    .presets { display: flex; gap: 6px; flex-wrap: wrap; }
-    .preset-btn { flex:1; min-width:68px; padding:7px 8px; border:1.5px solid var(--border); border-radius:10px; background:var(--card2); color:var(--text); font-size:.78rem; font-weight:600; cursor:pointer; transition:border-color .2s,background .2s; }
-    .preset-btn:hover { border-color:var(--accent); background:#2a2f4a; }
-    .preset-btn.active { border-color:var(--accent); background:rgba(108,138,255,.15); color:var(--accent); }
-    .noise-btn.active  { border-color:var(--yellow); background:rgba(251,191,36,.12); color:var(--yellow); }
-
-    /* ── Form elements ── */
-    input[type="number"], input[type="text"], select.styled {
-      background: var(--card2); border: 1.5px solid var(--border); border-radius: 8px;
-      color: var(--text); padding: 5px 9px; font-size: 0.85rem;
-    }
-    input[type="number"]:focus, input[type="text"]:focus, select.styled:focus { outline: none; border-color: var(--accent); }
-    input[type="range"] { accent-color: var(--accent); cursor: pointer; }
-    input[type="checkbox"] { accent-color: var(--accent); cursor: pointer; width:16px; height:16px; }
-
-    .unit-btn { padding:4px 10px; border:1.5px solid var(--border); border-radius:6px; background:var(--card2); color:var(--muted); font-size:.75rem; font-weight:600; cursor:pointer; }
-    .unit-btn.active { border-color:var(--accent); color:var(--accent); background:rgba(108,138,255,.1); }
-
-    label.small { font-size:.8rem; color:var(--muted); white-space:nowrap; }
-
-    /* ── Volume row ── */
-    .vol-row { display:flex; align-items:center; gap:10px; }
-    .vol-row input[type="range"] { flex:1; }
-    .vol-row span { font-size:.8rem; min-width:36px; text-align:right; }
-
-    /* ── Freq slider (page 1) ── */
-    .freq-slider-wrap { margin-top: 10px; }
-    .freq-slider-header { display:flex; justify-content:space-between; align-items:center; margin-bottom:8px; }
-    .freq-slider-val { font-size:1.3rem; font-weight:800; color:var(--accent); }
-    .freq-slider-sub { font-size:.75rem; color:var(--muted); margin-top:2px; }
-    #single-freq-range { width:100%; height:8px; }
-
-    /* ── Harmonics (page 2) ── */
-    .harmonics-header { display:grid; grid-template-columns:22px 1fr 80px 36px; gap:5px; padding:0 2px; margin-bottom:6px; }
-    .harmonics-header span { font-size:.68rem; color:var(--muted); text-transform:uppercase; letter-spacing:.05em; }
-    .harmonic-row { display:grid; grid-template-columns:22px 1fr 80px 36px; gap:5px; align-items:center; margin-bottom:4px; }
-    .harmonic-row .idx { font-size:.7rem; color:var(--muted); text-align:center; }
-    .freq-input-wrap { position:relative; display:flex; align-items:center; }
-    .freq-input-wrap input[type="text"] { padding:4px 30px 4px 7px; width:100%; font-size:.82rem; }
-    .freq-input-wrap input.active-freq { border-color:var(--accent); }
-    .freq-unit-toggle { position:absolute; right:4px; font-size:.65rem; color:var(--muted); cursor:pointer; padding:2px 3px; border-radius:4px; background:var(--border); user-select:none; }
-    .freq-unit-toggle:hover { color:var(--accent); }
-    .amp-val { font-size:.75rem; color:var(--muted); text-align:right; }
-    .harmonics-scroll { max-height:480px; overflow-y:auto; padding-right:4px; }
-    .harmonics-scroll::-webkit-scrollbar { width:4px; }
-    .harmonics-scroll::-webkit-scrollbar-thumb { background:var(--border); border-radius:4px; }
-
-    /* ── Graphs ── */
-    canvas { width:100%; height:200px; display:block; border-radius:10px; background:#0a0c14; }
-    canvas.short { height:160px; }
-    .graph-wrap { position:relative; margin-bottom:16px; }
-    .graph-wrap:last-child { margin-bottom:0; }
-    .graph-wrap h3 { font-size:.72rem; font-weight:700; text-transform:uppercase; letter-spacing:.08em; color:var(--muted); margin-bottom:8px; }
-    .tag { display:inline-block; font-size:.65rem; font-weight:700; padding:1px 7px; border-radius:20px; margin-left:6px; vertical-align:middle; }
-    .tag-gen { background:rgba(108,138,255,.2); color:var(--accent); }
-    .tag-rec { background:rgba(248,113,113,.2); color:var(--red); }
-    .tag-live { background:rgba(34,197,94,.2); color:var(--green); animation:pulse 1.5s infinite; }
-    @keyframes pulse { 0%,100%{opacity:1;} 50%{opacity:0.6;} }
-    .no-data { position:absolute; inset:0; display:flex; align-items:center; justify-content:center; color:var(--muted); font-size:.82rem; pointer-events:none; border-radius:10px; }
-
-    /* ── Rec status ── */
-    .rec-status { font-size:.82rem; color:var(--red); min-height:20px; margin-top:8px; text-align:center; }
-    .rec-status.ok { color:var(--green); }
-
-    /* ── Note picker ── */
-    .note-freq-display { font-size:.8rem; color:var(--accent); min-width:72px; }
-
-    /* ── Tag indicator ── */
-    .noise-indicator { display:inline-block; font-size:.65rem; font-weight:700; padding:1px 7px; border-radius:20px; margin-left:6px; vertical-align:middle; background:rgba(251,191,36,.15); color:var(--yellow); }
-
-    /* ── Collapsible ── */
-    .collapsible-header { display:flex; justify-content:space-between; align-items:center; cursor:pointer; user-select:none; }
-    .collapsible-header:hover h2 { color:var(--accent2); }
-    .collapsible-toggle { font-size:.7rem; color:var(--muted); transition:transform .2s; }
-    .collapsible-content { overflow:hidden; transition:max-height .3s ease-out; }
-    .collapsible-content.collapsed { max-height:0 !important; }
-
-    /* ── Tuner ── */
-    .tuner-note { font-size:2.5rem; font-weight:800; }
-    .tuner-freq { font-size:1rem; color:var(--muted); }
-    .tuner-cents { font-size:1.2rem; font-weight:700; }
-    .tuner-indicator { font-size:.85rem; font-weight:700; padding:4px 14px; border-radius:20px; }
-    .tuner-indicator.high { background:rgba(248,113,113,.2); color:var(--red); }
-    .tuner-indicator.low { background:rgba(108,138,255,.2); color:var(--accent); }
-    .tuner-indicator.in-tune { background:rgba(34,197,94,.2); color:var(--green); }
-    .tuner-off { background:rgba(100,116,139,.2); color:var(--muted); }
-
-    /* ── Metronome ── */
-    .metro-visual-row { display:grid; grid-template-columns:1fr 1fr; gap:20px; }
-    @media(max-width:800px){ .metro-visual-row { grid-template-columns:1fr; } }
-    .metro-pendulum-wrap { width:140px; height:200px; margin:0 auto; position:relative; background:var(--card2); border-radius:8px; overflow:hidden; }
-    .metro-pendulum { position:absolute; width:6px; height:140px; background:linear-gradient(to top, var(--accent), var(--accent2)); left:50%; bottom:20px; transform-origin:bottom center; border-radius:3px; }
-    .metro-pivot { position:absolute; bottom:16px; left:50%; transform:translateX(-50%); width:16px; height:16px; background:var(--border); border-radius:50%; }
-    .metro-weight { position:absolute; top:8px; left:50%; transform:translateX(-50%); width:20px; height:20px; background:var(--accent); border-radius:50%; }
-    .metro-level-wrap { width:60px; height:200px; margin:0 auto; background:var(--card2); border-radius:8px; position:relative; overflow:hidden; display:flex; flex-direction:column-reverse; padding:8px 6px; gap:3px; }
-    .metro-led { flex:1; border-radius:2px; background:var(--border); opacity:0.3; transition:opacity .05s, background .05s; }
-    .metro-led.on.green { background:var(--green); opacity:1; box-shadow:0 0 6px var(--green); }
-    .metro-led.on.yellow { background:#fbbf24; opacity:1; box-shadow:0 0 6px #fbbf24; }
-    .metro-led.on.red { background:#ef4444; opacity:1; box-shadow:0 0 6px #ef4444; }
-
-    /* ── Synth Pad ── */
-    .pad-key-grid { display:grid; grid-template-columns:repeat(4,1fr); gap:8px; margin-bottom:12px; }
-    .pad-key-btn { padding:12px 8px; border:1.5px solid var(--border); border-radius:10px; background:var(--card2); color:var(--text); font-size:1.1rem; font-weight:700; cursor:pointer; transition:border-color .2s,background .2s; }
-    .pad-key-btn:hover { border-color:var(--accent); background:#2a2f4a; }
-    .pad-key-btn.active { border-color:var(--accent); background:rgba(108,138,255,.2); color:var(--accent); }
-  </style>
+  <title>Audio Tools — Signal Generator</title>
+  <link rel="stylesheet" href="styles.css"/>
 </head>
 <body>
 
-<header>
-  <h1>🎛️ Audio Tools</h1>
-  <p>Signal generator · audio recorder · tuner · metronome · synth pads</p>
-  <div class="vol-row" style="justify-content:center;margin-top:10px;max-width:300px;margin-left:auto;margin-right:auto;">
+<header style="position:relative;text-align:center;padding:24px 20px 0;">
+  <h1 style="display:inline-block;margin:0;">🎛️ Audio Tools</h1>
+  <div class="vol-row" style="position:absolute;right:20px;top:50%;transform:translateY(-50%);margin:0;">
     <label class="small">Master Volume</label>
     <input type="range" id="master-volume" min="0" max="1" step="0.01" value="0.8" oninput="onMasterVolumeChange()"/>
     <span id="master-vol-label">80%</span>
@@ -342,9 +130,9 @@
         <div class="graph-wrap">
           <h3>Spectrum Analyser <span class="tag tag-gen">Generated</span> <span style="font-size:.65rem;color:var(--muted);">0 – 32 kHz</span>
             <select class="styled" id="power-range-p1-canvas-freq" onchange="onPowerRangeChange('p1-canvas-freq')" style="font-size:.7rem;padding:2px 4px;margin-left:8px;">
-              <option value="10">-10 dB</option>
+              <option value="10" selected>-10 dB</option>
               <option value="20">-20 dB</option>
-              <option value="40" selected>-40 dB</option>
+              <option value="40">-40 dB</option>
               <option value="80">-80 dB</option>
             </select>
           </h3>
@@ -462,9 +250,9 @@
         <div class="graph-wrap" style="position:relative;">
           <h3>Spectrum Analyser <span class="tag tag-rec" id="rec-freq-tag">Recorded</span> <span style="font-size:.65rem;color:var(--muted);">0 – 32 kHz</span>
             <select class="styled" id="power-range-rec-canvas-freq" onchange="onPowerRangeChange('rec-canvas-freq')" style="font-size:.7rem;padding:2px 4px;margin-left:8px;">
-              <option value="10">-10 dB</option>
+              <option value="10" selected>-10 dB</option>
               <option value="20">-20 dB</option>
-              <option value="40" selected>-40 dB</option>
+              <option value="40">-40 dB</option>
               <option value="80">-80 dB</option>
             </select>
           </h3>
@@ -555,9 +343,9 @@
         <div class="graph-wrap">
           <h3>Spectrum Analyser <span class="tag tag-live" id="tuner-freq-tag" style="display:none;">Live</span>
             <select class="styled" id="power-range-tuner-canvas-freq" onchange="onPowerRangeChange('tuner-canvas-freq')" style="font-size:.7rem;padding:2px 4px;margin-left:8px;">
-              <option value="10">-10 dB</option>
+              <option value="10" selected>-10 dB</option>
               <option value="20">-20 dB</option>
-              <option value="40" selected>-40 dB</option>
+              <option value="40">-40 dB</option>
               <option value="80">-80 dB</option>
             </select>
           </h3>

--- a/index.html
+++ b/index.html
@@ -188,9 +188,6 @@
     .collapsible-content.collapsed { max-height:0 !important; }
 
     /* ── Tuner ── */
-    .tuner-gauge { width:200px; height:200px; position:relative; margin:0 auto; }
-    .tuner-needle { position:absolute; width:4px; height:90px; background:#f87171; left:50%; bottom:50%; transform-origin:bottom center; border-radius:2px; transition:transform .08s ease-out; }
-    .tuner-center { position:absolute; width:12px; height:12px; background:var(--green); border-radius:50%; left:50%; top:50%; transform:translate(-50%,-50%); }
     .tuner-note { font-size:2.5rem; font-weight:800; }
     .tuner-freq { font-size:1rem; color:var(--muted); }
     .tuner-cents { font-size:1.2rem; font-weight:700; }
@@ -199,16 +196,14 @@
     .tuner-indicator.low { background:rgba(108,138,255,.2); color:var(--accent); }
     .tuner-indicator.in-tune { background:rgba(34,197,94,.2); color:var(--green); }
     .tuner-off { background:rgba(100,116,139,.2); color:var(--muted); }
-    @keyframes needle-shake { 0%,100%{transform:rotate(0);} 25%{transform:rotate(-3deg);} 75%{transform:rotate(3deg);} }
-    .tuner-needle.shaking { animation:needle-shake .15s infinite; }
 
     /* ── Metronome ── */
     .metro-visual-row { display:grid; grid-template-columns:1fr 1fr; gap:20px; }
     @media(max-width:800px){ .metro-visual-row { grid-template-columns:1fr; } }
     .metro-pendulum-wrap { width:140px; height:200px; margin:0 auto; position:relative; background:var(--card2); border-radius:8px; overflow:hidden; }
-    .metro-pendulum { position:absolute; width:6px; height:140px; background:linear-gradient(to bottom, var(--accent), var(--accent2)); left:50%; top:20px; transform-origin:top center; border-radius:3px; }
-    .metro-pivot { position:absolute; top:16px; left:50%; transform:translateX(-50%); width:16px; height:16px; background:var(--border); border-radius:50%; }
-    .metro-weight { position:absolute; bottom:8px; left:50%; transform:translateX(-50%); width:20px; height:20px; background:var(--accent); border-radius:50%; }
+    .metro-pendulum { position:absolute; width:6px; height:140px; background:linear-gradient(to top, var(--accent), var(--accent2)); left:50%; bottom:20px; transform-origin:bottom center; border-radius:3px; }
+    .metro-pivot { position:absolute; bottom:16px; left:50%; transform:translateX(-50%); width:16px; height:16px; background:var(--border); border-radius:50%; }
+    .metro-weight { position:absolute; top:8px; left:50%; transform:translateX(-50%); width:20px; height:20px; background:var(--accent); border-radius:50%; }
     .metro-level-wrap { width:60px; height:200px; margin:0 auto; background:var(--card2); border-radius:8px; position:relative; overflow:hidden; display:flex; flex-direction:column-reverse; padding:8px 6px; gap:3px; }
     .metro-led { flex:1; border-radius:2px; background:var(--border); opacity:0.3; transition:opacity .05s, background .05s; }
     .metro-led.on.green { background:var(--green); opacity:1; box-shadow:0 0 6px var(--green); }
@@ -232,10 +227,23 @@
     <input type="range" id="master-volume" min="0" max="1" step="0.01" value="0.8" oninput="onMasterVolumeChange()"/>
     <span id="master-vol-label">80%</span>
   </div>
-  <div style="margin-top:8px;" id="dev-controls">
-    <label style="display:inline-flex;align-items:center;gap:6px;cursor:pointer;font-size:.75rem;color:var(--muted);">
-      <input type="checkbox" id="prod-mode" onchange="toggleProdMode()"/>
-      <span>Prod Mode (hide Synth Pads)</span>
+  <div class="flex-row" style="justify-content:center;margin-top:6px;gap:8px;font-size:.75rem;color:var(--muted);">
+    <label style="display:flex;align-items:center;gap:4px;cursor:pointer;">
+      Spectrum Range:
+      <select class="styled" id="spectrum-range" onchange="onSpectrumRangeChange()" style="font-size:.75rem;padding:2px 4px;">
+        <option value="8000">8 kHz</option>
+        <option value="16000">16 kHz</option>
+        <option value="32000" selected>32 kHz</option>
+      </select>
+    </label>
+    <label style="display:flex;align-items:center;gap:4px;cursor:pointer;">
+      Min Power:
+      <select class="styled" id="power-range" onchange="onPowerRangeChange()" style="font-size:.75rem;padding:2px 4px;">
+        <option value="0">0 dB (full)</option>
+        <option value="40" selected>40 dB</option>
+        <option value="60">60 dB</option>
+        <option value="80">80 dB</option>
+      </select>
     </label>
   </div>
 </header>
@@ -505,23 +513,39 @@
           </div>
         </div>
         <div style="text-align:center;margin-top:10px;position:relative;">
-          <div class="tuner-gauge">
-            <div class="tuner-needle" id="tuner-needle"></div>
-            <div class="tuner-center"></div>
+          <div style="position:relative;width:200px;height:80px;margin:0 auto;background:var(--card2);border-radius:8px;">
+            <!-- Good enough zone markers -->
+            <div style="position:absolute;top:0;left:0;right:0;bottom:0;">
+              <div style="position:absolute;left:46%;right:54%;top:0;bottom:0;background:rgba(52,197,94,0.15);border-left:2px dashed rgba(52,197,94,0.4);border-right:2px dashed rgba(52,197,94,0.4);"></div>
+              <div style="position:absolute;left:49%;right:51%;top:0;bottom:0;background:rgba(52,197,94,0.3);border-left:1px solid rgba(52,197,94,0.6);border-right:1px solid rgba(52,197,94,0.6);"></div>
+            </div>
+            <div style="position:absolute;top:0;left:0;right:0;bottom:0;display:flex;align-items:flex-end;justify-content:center;gap:2px;padding:0 10px;">
+              <div style="flex:1;margin:0 1px;">
+                <div style="height:60%;background:var(--border);border-radius:2px 2px 0 0;" id="tuner-bar-low"></div>
+              </div>
+              <div style="flex:1;margin:0 1px;">
+                <div style="height:45%;background:var(--border);border-radius:2px 2px 0 0;" id="tuner-bar-mid"></div>
+              </div>
+              <div style="flex:1;margin:0 1px;">
+                <div style="height:60%;background:var(--border);border-radius:2px 2px 0 0;" id="tuner-bar-high"></div>
+              </div>
+            </div>
+            <div id="tuner-vbar" style="position:absolute;bottom:0;width:4px;height:100%;background:var(--green);border-radius:2px;transition:left 0.3s ease-out;left:50%;transform:translateX(-50%);"></div>
           </div>
           <div style="margin-top:8px;font-size:.7rem;color:var(--muted);">
-            ◀ <span style="color:var(--accent);">-50¢</span> │ <span style="color:var(--green);">0¢</span> │ <span style="color:var(--red);">+50¢</span> ▶
+            ◀ <span style="color:var(--accent);">-50¢</span> │ <span style="color:var(--green);">±5¢ good</span> │ <span style="color:var(--red);">+50¢</span> ▶
           </div>
         </div>
       </div>
 
-      <div class="card">
-        <h2>Microphone Input</h2>
-        <div class="flex-row" style="margin-bottom:12px;">
-          <button class="btn btn-primary" id="tuner-start-btn" onclick="toggleTuner()">▶ Start Tuner</button>
+        <div class="card">
+          <h2>Microphone Input</h2>
+          <div class="flex-row" style="margin-bottom:12px;">
+            <button class="btn btn-primary" id="tuner-start-btn" onclick="toggleTuner()">▶ Start Tuner</button>
+            <button class="btn btn-sm" id="tuner-play-note-btn" onclick="togglePlayTargetNote()" style="background:var(--card2);border:1.5px solid var(--accent);color:var(--accent);">🔊 Play Note</button>
+          </div>
+          <div class="rec-status" id="tuner-status">Press Start to begin</div>
         </div>
-        <div class="rec-status" id="tuner-status">Press Start to begin</div>
-      </div>
     </div>
 
     <!-- Right: spectrum analyser -->

--- a/index.html
+++ b/index.html
@@ -616,7 +616,7 @@
         <div class="vol-row" style="margin-bottom:12px;">
           <label class="small">Volume</label>
           <input type="range" id="metro-volume" min="0" max="1" step="0.01" value="0.7" oninput="onMetroVolumeChange()"/>
-          <span id="metro-vol-label">30%</span>
+          <span id="metro-vol-label">70%</span>
         </div>
         <div class="flex-row">
           <button class="btn btn-primary" id="metro-play-btn" onclick="toggleMetronome()" style="flex:1;">▶ Start</button>

--- a/javascript/drawing.js
+++ b/javascript/drawing.js
@@ -73,11 +73,12 @@ function drawLiveFreq(canvasId, analyser) {
 
 function drawFreqBars(ctx, W, H, data, sampleRate) {
   const nyquist = sampleRate/2;
-  const maxDisplay = Math.min(MAX_FREQ, nyquist);
+  const maxDisplay = Math.min(getSpectrumRange(), nyquist);
   const MIN_FREQ_LOG = 10;
   const padX = 40;
   const padBot = 22;
   const usableW = W - padX - 10;
+  const powerRange = getPowerRange(); // dB range to display
 
   // Find max value for normalization
   let maxVal = 0;
@@ -92,7 +93,9 @@ function drawFreqBars(ctx, W, H, data, sampleRate) {
     const bin = Math.floor((freq/nyquist)*data.length);
     if(bin >= data.length) break;
     const x = padX + frac * usableW;
-    const barH = (data[bin]/maxVal)*(H-padBot-5);
+    // Scale bar height based on power range (0 dB = full range, 80 dB = only loudest signals)
+    const normalizedVal = data[bin] / maxVal;
+    const barH = Math.pow(normalizedVal, powerRange / 40) * (H - padBot - 5);
     const hue = 200+(data[bin]/255)*60;
     ctx.fillStyle=`hsl(${hue},80%,60%)`;
     const barW = Math.max(1, (1/numBars) * usableW - 1);

--- a/javascript/drawing.js
+++ b/javascript/drawing.js
@@ -148,29 +148,34 @@ function drawPowerAxis(ctx, W, H, padX, padBot, powerRange) {
     dbValues.push(db);
   }
 
-  // Always show -6 dB (amplitude = 0.5)
-  if (!dbValues.includes(-6)) {
-    dbValues.push(-6);
-    dbValues.sort((a, b) => b - a); // Sort descending
-  }
+  // Always show -6 dB (amplitude = 0.5) and minDB (bottom of y-axis)
+  [minDB, -6].forEach(db => {
+    if (!dbValues.includes(db)) {
+      dbValues.push(db);
+    }
+  });
+  dbValues.sort((a, b) => b - a); // Sort descending
 
   for (const db of dbValues) {
     // Map dB to y-position: minDB = 0 height, 0 dB = full height
     const barH = ((db - minDB) / Math.abs(minDB)) * graphH;
     const y = H - padBot - barH;
 
-    if (y < 5 || y > H - padBot - 2) continue;
+    // Skip if too close to top; allow bottom label (minDB) even at y = H - padBot
+    if (y < 5) continue;
 
-    // Draw grid line
-    ctx.strokeStyle='#1e2235';
-    ctx.lineWidth=1;
-    ctx.beginPath();
-    ctx.moveTo(padX, y);
-    ctx.lineTo(W, y);
-    ctx.stroke();
+    // Draw grid line (skip for minDB at bottom)
+    if (db !== minDB) {
+      ctx.strokeStyle='#1e2235';
+      ctx.lineWidth=1;
+      ctx.beginPath();
+      ctx.moveTo(padX, y);
+      ctx.lineTo(W, y);
+      ctx.stroke();
+    }
 
     // Draw label
-    ctx.fillText(`${db} dB`, padX - 5, y + 3);
+    ctx.fillText(`${db} dB`, padX - 5, Math.min(y + 3, H - padBot));
   }
 }
 
@@ -183,6 +188,8 @@ function drawLogFreqLabels(ctx,W,H,padX,padBot) {
     const x=padX+(Math.log(f/MIN_FREQ_LOG)/Math.log(maxDisplay/MIN_FREQ_LOG))*(W-padX-10);
     ctx.fillText(f>=1000?`${f/1000}k`:f, x, H-5);
   });
+  // Always show label at right end of x-axis (32k)
+  ctx.fillText('32k', W-5, H-5);
 }
 
 function drawNoiseTime(canvasId, type) {

--- a/javascript/drawing.js
+++ b/javascript/drawing.js
@@ -30,7 +30,7 @@ function drawStaticFreq(canvasId, components) {
   if (!active.length){drawNoDataText(ctx,W,H,'Add frequencies');return;}
 
   // Convert component data to frequency spectrum data for drawFreqBars
-  const maxDisplay = getSpectrumRange();
+  const maxDisplay = 32000; // Fixed max display frequency (spectrum range selector removed)
   const sampleRate = 44100; // Assume standard sample rate for display
   const nyquist = sampleRate / 2;
   const bufLen = 2048; // Match typical analyser fftSize
@@ -48,7 +48,7 @@ function drawStaticFreq(canvasId, components) {
   });
 
   // Use shared spectrum display function
-  drawFreqBars(ctx, W, H, freqData, sampleRate);
+  drawFreqBars(ctx, W, H, freqData, sampleRate, canvasId);
 
   // Draw frequency labels for components
   const padX = 40;
@@ -85,17 +85,18 @@ function drawLiveFreq(canvasId, analyser) {
   analyser.getByteFrequencyData(data);
   const sampleRate = audioCtx ? audioCtx.sampleRate : 44100;
   drawGrid(ctx,W,H);
-  drawFreqBars(ctx,W,H,data,sampleRate);
+  drawFreqBars(ctx,W,H,data,sampleRate,canvasId);
 }
 
-function drawFreqBars(ctx, W, H, data, sampleRate) {
+function drawFreqBars(ctx, W, H, data, sampleRate, canvasId) {
   const nyquist = sampleRate/2;
-  const maxDisplay = Math.min(getSpectrumRange(), nyquist);
+  const maxDisplay = Math.min(32000, nyquist); // Fixed max display (spectrum range selector removed)
   const MIN_FREQ_LOG = 10;
   const padX = 40;
   const padBot = 22;
   const usableW = W - padX - 10;
-  const powerRange = getPowerRange(); // dB range to display
+  const powerRange = getPowerRange(canvasId); // dB range to display (10=-10dB, 20=-20dB, etc.)
+  const minDB = -powerRange; // Minimum dB value (e.g., -40 dB)
 
   // Find max value for normalization
   let maxVal = 0;
@@ -104,15 +105,18 @@ function drawFreqBars(ctx, W, H, data, sampleRate) {
 
   // Draw bars at logarithmic positions
   const numBars = 200;
+  const graphH = H - padBot - 5;
   for(let i=0;i<numBars;i++){
     const frac = i/numBars;
     const freq = MIN_FREQ_LOG * Math.pow(maxDisplay/MIN_FREQ_LOG, frac);
     const bin = Math.floor((freq/nyquist)*data.length);
     if(bin >= data.length) break;
     const x = padX + frac * usableW;
-    // Scale bar height based on power range (0 dB = full range, 80 dB = only loudest signals)
+    // Convert linear value to dB
     const normalizedVal = data[bin] / maxVal;
-    const barH = Math.pow(normalizedVal, powerRange / 40) * (H - padBot - 5);
+    const db = 20 * Math.log10(Math.max(normalizedVal, 0.00000001)); // Avoid -Infinity
+    // Map dB to height: minDB = 0 height, 0 dB = full height
+    const barH = Math.max(0, (db - minDB) / Math.abs(minDB)) * graphH;
     const hue = 200+(data[bin]/255)*60;
     ctx.fillStyle=`hsl(${hue},80%,60%)`;
     const barW = Math.max(1, (1/numBars) * usableW - 1);
@@ -134,19 +138,25 @@ function drawPowerAxis(ctx, W, H, padX, padBot, powerRange) {
   ctx.textAlign='right';
 
   const graphH = H - padBot - 5;
+  const minDB = -powerRange; // powerRange is positive (10, 20, 40, 80), minDB is negative
 
   // dB values to display based on power range
   const dbValues = [0];
-  const step = powerRange <= 40 ? 10 : 20;
-  for (let db = -step; db >= -powerRange; db -= step) {
+  const step = powerRange <= 20 ? 5 : (powerRange <= 40 ? 10 : 20);
+  for (let db = -step; db >= minDB; db -= step) {
+    if (db === -5) continue; // -5 dB is not important, skip it
     dbValues.push(db);
   }
 
+  // Always show -6 dB (amplitude = 0.5)
+  if (!dbValues.includes(-6)) {
+    dbValues.push(-6);
+    dbValues.sort((a, b) => b - a); // Sort descending
+  }
+
   for (const db of dbValues) {
-    // Map dB to y-position using same formula as bar height
-    // barH = 10^(dB/20 * powerRange/40) * graphH
-    const exponent = (db / 20) * (powerRange / 40);
-    const barH = Math.pow(10, exponent) * graphH;
+    // Map dB to y-position: minDB = 0 height, 0 dB = full height
+    const barH = ((db - minDB) / Math.abs(minDB)) * graphH;
     const y = H - padBot - barH;
 
     if (y < 5 || y > H - padBot - 2) continue;
@@ -166,7 +176,7 @@ function drawPowerAxis(ctx, W, H, padX, padBot, powerRange) {
 
 function drawLogFreqLabels(ctx,W,H,padX,padBot) {
   ctx.fillStyle='#64748b'; ctx.font='10px Segoe UI'; ctx.textAlign='center';
-  const maxDisplay = getSpectrumRange();
+  const maxDisplay = 32000; // Fixed max display (spectrum range selector removed)
   const MIN_FREQ_LOG = 10;
   [10,20,50,100,200,500,1000,2000,5000,10000,20000].forEach(f=>{
     if(f>maxDisplay) return;
@@ -196,7 +206,7 @@ function drawNoiseFreq(canvasId, type) {
   const padBot=22;
   const padX=40;
   const minFreq = 10;
-  const maxDisplay = getSpectrumRange();
+  const maxDisplay = 32000; // Fixed max display (spectrum range selector removed)
   const usableW = W - padX - 10;
   for(let i=0;i<W;i++){
     const frac = i/usableW;

--- a/javascript/drawing.js
+++ b/javascript/drawing.js
@@ -28,22 +28,39 @@ function drawStaticFreq(canvasId, components) {
   drawGrid(ctx,W,H);
   const active=components.filter(c=>c.freq>0&&c.amp>0);
   if (!active.length){drawNoDataText(ctx,W,H,'Add frequencies');return;}
-  const maxAmp=Math.max(...active.map(c=>c.amp));
-  const padX=40,padBot=22,padTop=10;
-  const MIN_FREQ_LOG = 10;
+
+  // Convert component data to frequency spectrum data for drawFreqBars
+  const maxDisplay = getSpectrumRange();
+  const sampleRate = 44100; // Assume standard sample rate for display
+  const nyquist = sampleRate / 2;
+  const bufLen = 2048; // Match typical analyser fftSize
+  const freqData = new Uint8Array(bufLen);
+
+  // Map components to frequency bins
+  const maxAmp = Math.max(...active.map(c=>c.amp));
   active.forEach(c=>{
-    const x=padX+(Math.log(c.freq/MIN_FREQ_LOG)/Math.log(MAX_FREQ/MIN_FREQ_LOG))*(W-padX-10);
-    const barH=(c.amp/maxAmp)*(H-padTop-padBot);
-    const y=H-padBot-barH;
-    const grad=ctx.createLinearGradient(0,y,0,H-padBot);
-    grad.addColorStop(0,'#6c8aff'); grad.addColorStop(1,'rgba(108,138,255,.15)');
-    ctx.fillStyle=grad; ctx.fillRect(x-2,y,4,barH);
-    ctx.fillStyle='#94a3b8'; ctx.font='9px Segoe UI'; ctx.textAlign='center';
+    if (c.freq > maxDisplay || c.freq > nyquist) return;
+    const bin = Math.floor((c.freq / nyquist) * bufLen);
+    if (bin < bufLen) {
+      // Scale amplitude to 0-255 range
+      freqData[bin] = Math.max(freqData[bin], Math.round((c.amp / maxAmp) * 255));
+    }
+  });
+
+  // Use shared spectrum display function
+  drawFreqBars(ctx, W, H, freqData, sampleRate);
+
+  // Draw frequency labels for components
+  const padX = 40;
+  const padBot = 22;
+  ctx.fillStyle='#94a3b8'; ctx.font='9px Segoe UI'; ctx.textAlign='center';
+  active.forEach(c=>{
+    if (c.freq > maxDisplay) return;
+    const MIN_FREQ_LOG = 10;
+    const usableW = W - padX - 10;
+    const x = padX + (Math.log(c.freq / MIN_FREQ_LOG) / Math.log(maxDisplay / MIN_FREQ_LOG)) * usableW;
     ctx.fillText(c.freq>=1000?`${(c.freq/1000).toFixed(1)}k`:`${Math.round(c.freq)}`,x,H-5);
   });
-  ctx.strokeStyle='#2e3250'; ctx.lineWidth=1;
-  ctx.beginPath(); ctx.moveTo(padX,H-padBot); ctx.lineTo(W,H-padBot); ctx.stroke();
-  drawLogFreqLabels(ctx,W,H,padX,padBot);
 }
 
 function drawLiveTime(canvasId, analyser) {
@@ -106,14 +123,54 @@ function drawFreqBars(ctx, W, H, data, sampleRate) {
   ctx.strokeStyle='#2e3250'; ctx.lineWidth=1;
   ctx.beginPath(); ctx.moveTo(padX,H-padBot); ctx.lineTo(W,H-padBot); ctx.stroke();
   drawLogFreqLabels(ctx,W,H,padX,padBot);
+
+  // Y axis - power labels
+  drawPowerAxis(ctx, W, H, padX, padBot, powerRange);
+}
+
+function drawPowerAxis(ctx, W, H, padX, padBot, powerRange) {
+  ctx.fillStyle='#64748b';
+  ctx.font='10px Segoe UI';
+  ctx.textAlign='right';
+
+  const graphH = H - padBot - 5;
+
+  // dB values to display based on power range
+  const dbValues = [0];
+  const step = powerRange <= 40 ? 10 : 20;
+  for (let db = -step; db >= -powerRange; db -= step) {
+    dbValues.push(db);
+  }
+
+  for (const db of dbValues) {
+    // Map dB to y-position using same formula as bar height
+    // barH = 10^(dB/20 * powerRange/40) * graphH
+    const exponent = (db / 20) * (powerRange / 40);
+    const barH = Math.pow(10, exponent) * graphH;
+    const y = H - padBot - barH;
+
+    if (y < 5 || y > H - padBot - 2) continue;
+
+    // Draw grid line
+    ctx.strokeStyle='#1e2235';
+    ctx.lineWidth=1;
+    ctx.beginPath();
+    ctx.moveTo(padX, y);
+    ctx.lineTo(W, y);
+    ctx.stroke();
+
+    // Draw label
+    ctx.fillText(`${db} dB`, padX - 5, y + 3);
+  }
 }
 
 function drawLogFreqLabels(ctx,W,H,padX,padBot) {
   ctx.fillStyle='#64748b'; ctx.font='10px Segoe UI'; ctx.textAlign='center';
+  const maxDisplay = getSpectrumRange();
+  const MIN_FREQ_LOG = 10;
   [10,20,50,100,200,500,1000,2000,5000,10000,20000].forEach(f=>{
-    if(f>MAX_FREQ) return;
-    const MIN_FREQ_LOG = 10;
-    const x=padX+(Math.log(f/MIN_FREQ_LOG)/Math.log(MAX_FREQ/MIN_FREQ_LOG))*(W-padX-10);
+    if(f>maxDisplay) return;
+    const x=padX+(Math.log(f/MIN_FREQ_LOG)/Math.log(maxDisplay/MIN_FREQ_LOG))*(W-padX-10);
     ctx.fillText(f>=1000?`${f/1000}k`:f, x, H-5);
   });
 }
@@ -138,11 +195,13 @@ function drawNoiseFreq(canvasId, type) {
   drawGrid(ctx,W,H);
   const padBot=22;
   const padX=40;
-  const MIN_FREQ_LOG = 10;
+  const minFreq = 10;
+  const maxDisplay = getSpectrumRange();
+  const usableW = W - padX - 10;
   for(let i=0;i<W;i++){
-    const frac = i/(W-1);
-    const freq = MIN_FREQ_LOG * Math.pow(MAX_FREQ/MIN_FREQ_LOG, frac);
-    const f = freq/MAX_FREQ;
+    const frac = i/usableW;
+    const freq = minFreq * Math.pow(maxDisplay/minFreq, frac);
+    const f = freq/maxDisplay;
     let amp;
     if (type==='white') amp=0.85+(Math.random()-.5)*.1;
     else if (type==='pink') amp=(1-f*.7)*(0.85+(Math.random()-.5)*.1);

--- a/javascript/recorder.js
+++ b/javascript/recorder.js
@@ -24,6 +24,7 @@ let pbOffset       = 0;
 let pbAnim         = null;
 let pbLoopStartTime = 0;
 let recAnalyser    = null;
+let recAnalyserCtx = null;
 let recAnim        = null;
 
 function onRecVolChange() {
@@ -43,15 +44,19 @@ async function toggleLiveMonitor() {
 async function startLiveMonitor() {
   try {
     if (isRecording) stopRecording();
+    if (typeof stopTuner === 'function') stopTuner();
     const stream = await navigator.mediaDevices.getUserMedia({audio:true,video:false});
     liveStream = stream;
-    liveCtx = ensureAudioCtx();
+
+    // Create a separate AudioContext that is NEVER connected to speakers
+    // This prevents any possibility of mic audio reaching the output
+    liveCtx = new (window.AudioContext||window.webkitAudioContext)();
     liveAnalyser = liveCtx.createAnalyser();
     liveAnalyser.fftSize = 8192;
     liveAnalyser.smoothingTimeConstant = 0.6;
     const source = liveCtx.createMediaStreamSource(stream);
     source.connect(liveAnalyser);
-    liveAnalyser.connect(getMasterGain());
+    // Analyser is NOT connected to any destination - completely silent
 
     isLiveMonitor = true;
     document.getElementById('live-monitor').checked = true;
@@ -84,8 +89,12 @@ function stopLiveMonitor() {
     liveStream.getTracks().forEach(t => t.stop());
     liveStream = null;
   }
-  // Don't close shared audioCtx - just disconnect analyser
+  // Close the separate AudioContext used for live monitoring
+  if (liveCtx && liveCtx.state !== 'closed') {
+    liveCtx.close();
+  }
   liveAnalyser = null;
+  liveCtx = null;
   isLiveMonitor = false;
   document.getElementById('live-monitor').checked = false;
   document.getElementById('live-status').textContent = 'Monitor off';
@@ -110,15 +119,18 @@ async function toggleRecord() {
 async function startRecording() {
   try {
     if (isLiveMonitor) stopLiveMonitor();
+    if (typeof stopTuner === 'function') stopTuner();
     const stream = await navigator.mediaDevices.getUserMedia({audio:true,video:false});
     recChunks=[]; recordedBlob=null; recordedBuffer=null;
     document.getElementById('pb-btn').disabled=true;
     document.getElementById('pb-progress').style.width='0%';
 
-    recAnalyser = ensureAudioCtx().createAnalyser();
+    // Use a separate context for the recording analyser to avoid any possibility of feedback
+    recAnalyserCtx = new (window.AudioContext || window.webkitAudioContext)();
+    recAnalyser = recAnalyserCtx.createAnalyser();
     recAnalyser.fftSize = 8192;
     recAnalyser.smoothingTimeConstant = 0.6;
-    const micSource = audioCtx.createMediaStreamSource(stream);
+    const micSource = recAnalyserCtx.createMediaStreamSource(stream);
     micSource.connect(recAnalyser);
 
     mediaRecorder=new MediaRecorder(stream);
@@ -159,7 +171,14 @@ function stopRecording() {
   if (mediaRecorder&&mediaRecorder.state!=='inactive') mediaRecorder.stop();
   mediaRecorder?.stream?.getTracks().forEach(t=>t.stop());
   isRecording=false;
+
+  // Close the separate recording analysis context
+  if (recAnalyserCtx && recAnalyserCtx.state !== 'closed') {
+    recAnalyserCtx.close();
+  }
+  recAnalyserCtx = null;
   recAnalyser = null;
+
   document.getElementById('rec-btn').textContent='⏺ Record';
   document.getElementById('rec-btn').classList.remove('recording');
   const timeTag = document.getElementById('rec-time-tag');

--- a/javascript/shared.js
+++ b/javascript/shared.js
@@ -53,3 +53,32 @@ function onMasterVolumeChange() {
   document.getElementById('master-vol-label').textContent = Math.round(v*100)+'%';
   if (masterGain) masterGain.gain.value = v;
 }
+
+// Global spectrum range (synced across all instances)
+function getSpectrumRange() {
+  return parseInt(document.getElementById('spectrum-range')?.value || 32000);
+}
+
+function onSpectrumRangeChange() {
+  // Redraw all active spectrum displays
+  if (typeof drawP1Graphs === 'function' && document.getElementById('page-presets').classList.contains('active')) {
+    drawP1Graphs();
+  }
+  // Force redraw of active tab's spectrum
+  const activeTab = document.querySelector('.tab.active');
+  if (activeTab) {
+    const idx = Array.from(document.querySelectorAll('.tab')).indexOf(activeTab);
+    const pages = ['page-presets', 'page-recorder', 'page-tuner', 'page-metronome', 'page-pads'];
+    if (pages[idx]) showTab(pages[idx]);
+  }
+}
+
+// Power range (y-axis) for spectrum analyzer
+function getPowerRange() {
+  return parseInt(document.getElementById('power-range')?.value || 40);
+}
+
+function onPowerRangeChange() {
+  // Same redraw logic as spectrum range change
+  onSpectrumRangeChange();
+}

--- a/javascript/shared.js
+++ b/javascript/shared.js
@@ -54,31 +54,26 @@ function onMasterVolumeChange() {
   if (masterGain) masterGain.gain.value = v;
 }
 
-// Global spectrum range (synced across all instances)
-function getSpectrumRange() {
-  return parseInt(document.getElementById('spectrum-range')?.value || 32000);
+// Power range (y-axis) for spectrum analyzer - global setting synced across all pages
+let globalPowerRange = 40; // Default -40 dB
+
+function getPowerRange(canvasId) {
+  return globalPowerRange;
 }
 
-function onSpectrumRangeChange() {
-  // Redraw all active spectrum displays
-  if (typeof drawP1Graphs === 'function' && document.getElementById('page-presets').classList.contains('active')) {
-    drawP1Graphs();
+function onPowerRangeChange(canvasId) {
+  const newVal = parseInt(document.getElementById('power-range-' + canvasId)?.value || 40);
+  globalPowerRange = newVal;
+
+  // Sync all dropdowns to the new value
+  ['p1-canvas-freq', 'rec-canvas-freq', 'tuner-canvas-freq'].forEach(id => {
+    const dd = document.getElementById('power-range-' + id);
+    if (dd && dd.value != newVal) dd.value = newVal;
+  });
+
+  // Redraw the specific spectrum display
+  if (canvasId === 'p1-canvas-freq') {
+    if (typeof drawP1Graphs === 'function') drawP1Graphs();
   }
-  // Force redraw of active tab's spectrum
-  const activeTab = document.querySelector('.tab.active');
-  if (activeTab) {
-    const idx = Array.from(document.querySelectorAll('.tab')).indexOf(activeTab);
-    const pages = ['page-presets', 'page-recorder', 'page-tuner', 'page-metronome', 'page-pads'];
-    if (pages[idx]) showTab(pages[idx]);
-  }
-}
-
-// Power range (y-axis) for spectrum analyzer
-function getPowerRange() {
-  return parseInt(document.getElementById('power-range')?.value || 40);
-}
-
-function onPowerRangeChange() {
-  // Same redraw logic as spectrum range change
-  onSpectrumRangeChange();
+  // For recorder and tuner, the live draw functions will pick up the new power range automatically
 }

--- a/javascript/shared.js
+++ b/javascript/shared.js
@@ -55,7 +55,7 @@ function onMasterVolumeChange() {
 }
 
 // Power range (y-axis) for spectrum analyzer - global setting synced across all pages
-let globalPowerRange = 40; // Default -40 dB
+let globalPowerRange = 10; // Default -10 dB
 
 function getPowerRange(canvasId) {
   return globalPowerRange;

--- a/javascript/tuner.js
+++ b/javascript/tuner.js
@@ -38,6 +38,46 @@ function setTunerMiddleC() {
   onTunerNoteSelect();
 }
 
+let tunerNoteOsc = null;
+let tunerNoteGain = null;
+let tunerNotePlaying = false;
+function togglePlayTargetNote() {
+  if (tunerNotePlaying) {
+    stopTargetNote();
+  } else {
+    startTargetNote();
+  }
+}
+function startTargetNote() {
+  if (!tunerTargetFreq) return;
+  ensureAudioCtx();
+  stopTargetNote(); // Stop any existing note
+  const now = audioCtx.currentTime;
+  tunerNoteOsc = audioCtx.createOscillator();
+  tunerNoteGain = audioCtx.createGain();
+  tunerNoteOsc.type = 'sine';
+  tunerNoteOsc.frequency.setValueAtTime(tunerTargetFreq, now);
+  tunerNoteGain.gain.setValueAtTime(0, now);
+  tunerNoteGain.gain.linearRampToValueAtTime(0.3, now + 0.05);
+  tunerNoteOsc.connect(tunerNoteGain);
+  tunerNoteGain.connect(getMasterGain());
+  tunerNoteOsc.start(now);
+  tunerNotePlaying = true;
+  document.getElementById('tuner-play-note-btn').textContent = '⏹ Stop Note';
+}
+function stopTargetNote() {
+  if (tunerNoteOsc) {
+    try {
+      tunerNoteGain.gain.linearRampToValueAtTime(0.001, audioCtx.currentTime + 0.1);
+      tunerNoteOsc.stop(audioCtx.currentTime + 0.1);
+    } catch(e) {}
+    tunerNoteOsc = null;
+    tunerNoteGain = null;
+  }
+  tunerNotePlaying = false;
+  document.getElementById('tuner-play-note-btn').textContent = '🔊 Play Note';
+}
+
 async function toggleTuner() {
   tunerActive ? stopTuner() : await startTuner();
 }
@@ -101,9 +141,14 @@ function stopTuner() {
 }
 
 function resetTunerDisplay() {
-  const needle = document.getElementById('tuner-needle');
-  needle.style.transform = 'rotate(0deg)';
-  needle.classList.remove('shaking');
+  const vbar = document.getElementById('tuner-vbar');
+  const barLow = document.getElementById('tuner-bar-low');
+  const barMid = document.getElementById('tuner-bar-mid');
+  const barHigh = document.getElementById('tuner-bar-high');
+  vbar.style.left = '50%';
+  barLow.style.background = 'var(--border)';
+  barMid.style.background = 'var(--border)';
+  barHigh.style.background = 'var(--border)';
   document.getElementById('tuner-display-cents').textContent = '—';
   document.getElementById('tuner-indicator').textContent = 'OFF';
   document.getElementById('tuner-indicator').className = 'tuner-indicator tuner-off';
@@ -120,34 +165,49 @@ function processTunerData() {
   const detectedFreq = detectPitchAutoCorr(data, TUNER_SAMPLE_RATE, 50, 2000);
   const centsLabel = document.getElementById('tuner-display-cents');
   const indicator = document.getElementById('tuner-indicator');
-  const needle = document.getElementById('tuner-needle');
+  const vbar = document.getElementById('tuner-vbar');
+  const barLow = document.getElementById('tuner-bar-low');
+  const barMid = document.getElementById('tuner-bar-mid');
+  const barHigh = document.getElementById('tuner-bar-high');
 
   if (!detectedFreq || detectedFreq < 30 || detectedFreq > 5000 || !isStablePitch(data)) {
     centsLabel.textContent = '—';
     indicator.textContent = 'NO pitch';
     indicator.className = 'tuner-indicator tuner-off';
-    needle.style.transform = 'rotate(0deg)';
-    needle.classList.add('shaking');
+    vbar.style.left = '50%';
+    barLow.style.background = 'var(--border)';
+    barMid.style.background = 'var(--border)';
+    barHigh.style.background = 'var(--border)';
     return;
   }
 
   const cents = Math.round(1200 * Math.log2(detectedFreq / tunerTargetFreq));
   centsLabel.textContent = (cents > 0 ? '+' : '') + cents + '¢';
 
+  // Update vertical bar position (0% = -50 cents, 100% = +50 cents)
+  const pct = Math.max(0, Math.min(100, (cents + 50) * 2));
+  vbar.style.left = pct + '%';
+
+  // Update bar colors based on deviation
   if (Math.abs(cents) <= 5) {
     indicator.textContent = 'IN TUNE';
     indicator.className = 'tuner-indicator in-tune';
+    barLow.style.background = 'var(--green)';
+    barMid.style.background = 'var(--green)';
+    barHigh.style.background = 'var(--green)';
   } else if (cents > 0) {
     indicator.textContent = 'TOO HIGH';
     indicator.className = 'tuner-indicator high';
+    barLow.style.background = 'var(--red)';
+    barMid.style.background = cents > 25 ? 'var(--red)' : 'var(--border)';
+    barHigh.style.background = 'var(--red)';
   } else {
     indicator.textContent = 'TOO LOW';
     indicator.className = 'tuner-indicator low';
+    barLow.style.background = 'var(--accent)';
+    barMid.style.background = cents < -25 ? 'var(--accent)' : 'var(--border)';
+    barHigh.style.background = 'var(--accent)';
   }
-
-  const angle = Math.max(-50, Math.min(50, cents));
-  needle.style.transform = `rotate(${angle}deg)`;
-  needle.classList.remove('shaking');
 }
 
 function detectPitchAutoCorr(data, sampleRate, minFreq, maxFreq) {

--- a/javascript/tuner.js
+++ b/javascript/tuner.js
@@ -41,17 +41,20 @@ function setTunerMiddleC() {
 let tunerNoteOsc = null;
 let tunerNoteGain = null;
 let tunerNotePlaying = false;
+let tunerAlternating = false;
+let tunerAlternatingInterval = null;
+const ALTERNATING_PERIOD = 1000; // 1 second
+
 function togglePlayTargetNote() {
-  if (tunerNotePlaying) {
+  if (tunerNotePlaying || tunerAlternating) {
     stopTargetNote();
   } else {
     startTargetNote();
   }
 }
-function startTargetNote() {
-  if (!tunerTargetFreq) return;
-  ensureAudioCtx();
-  stopTargetNote(); // Stop any existing note
+
+function playNoteSound() {
+  if (!tunerTargetFreq || tunerNotePlaying) return;
   const now = audioCtx.currentTime;
   tunerNoteOsc = audioCtx.createOscillator();
   tunerNoteGain = audioCtx.createGain();
@@ -63,9 +66,9 @@ function startTargetNote() {
   tunerNoteGain.connect(getMasterGain());
   tunerNoteOsc.start(now);
   tunerNotePlaying = true;
-  document.getElementById('tuner-play-note-btn').textContent = '⏹ Stop Note';
 }
-function stopTargetNote() {
+
+function stopNoteSound() {
   if (tunerNoteOsc) {
     try {
       tunerNoteGain.gain.linearRampToValueAtTime(0.001, audioCtx.currentTime + 0.1);
@@ -75,7 +78,52 @@ function stopTargetNote() {
     tunerNoteGain = null;
   }
   tunerNotePlaying = false;
+}
+
+function startTargetNote() {
+  if (!tunerTargetFreq) return;
+  ensureAudioCtx();
+  stopTargetNote(); // Stop any existing note
+
+  if (tunerActive) {
+    // Tuner is active, enter alternating mode
+    tunerAlternating = true;
+    playNoteSound();
+
+    // Set up timer to alternate every second
+    tunerAlternatingInterval = setInterval(() => {
+      if (tunerNotePlaying) {
+        stopNoteSound();
+        document.getElementById('tuner-status').textContent = 'Listening...';
+      } else {
+        playNoteSound();
+        document.getElementById('tuner-status').textContent = 'Note playing...';
+      }
+    }, ALTERNATING_PERIOD);
+
+    document.getElementById('tuner-play-note-btn').textContent = '⏹ Alternating';
+    document.getElementById('tuner-status').textContent = 'Note playing...';
+  } else {
+    // Normal behavior - just play the note
+    playNoteSound();
+    document.getElementById('tuner-play-note-btn').textContent = '⏹ Stop Note';
+  }
+}
+
+function stopTargetNote() {
+  // Stop alternating mode if active
+  if (tunerAlternating) {
+    tunerAlternating = false;
+    if (tunerAlternatingInterval) {
+      clearInterval(tunerAlternatingInterval);
+      tunerAlternatingInterval = null;
+    }
+  }
+  stopNoteSound();
   document.getElementById('tuner-play-note-btn').textContent = '🔊 Play Note';
+  if (tunerActive) {
+    document.getElementById('tuner-status').textContent = 'Listening...';
+  }
 }
 
 async function toggleTuner() {
@@ -88,15 +136,25 @@ async function startTuner() {
     return;
   }
   try {
+    // Stop other mic-using features to avoid conflicts and feedback
+    if (typeof stopLiveMonitor === 'function') stopLiveMonitor();
+    if (typeof stopRecording === 'function') stopRecording();
+
     const stream = await navigator.mediaDevices.getUserMedia({audio:true, video:false});
     tunerStream = stream;
-    tunerAudioCtx = ensureAudioCtx();
+    
+    // Use a separate AudioContext for the tuner mic input.
+    // This physically isolates the microphone from the shared audioCtx 
+    // that is connected to the speakers, preventing any possibility of feedback.
+    tunerAudioCtx = new (window.AudioContext || window.webkitAudioContext)();
+    if (tunerAudioCtx.state === 'suspended') await tunerAudioCtx.resume();
+
     tunerAnalyser = tunerAudioCtx.createAnalyser();
     tunerAnalyser.fftSize = TUNER_FFT_SIZE;
     tunerAnalyser.smoothingTimeConstant = 0.8;
     const source = tunerAudioCtx.createMediaStreamSource(stream);
     source.connect(tunerAnalyser);
-    tunerAnalyser.connect(getMasterGain());
+    // Analyser is NOT connected to tunerAudioCtx.destination - completely silent
 
     tunerActive = true;
     document.getElementById('tuner-start-btn').textContent = '⏹ Stop Tuner';
@@ -110,9 +168,12 @@ async function startTuner() {
 
     (function tunerLoop() {
       if (!tunerActive) return;
-      processTunerData();
-      drawLiveTime('tuner-canvas-time', tunerAnalyser);
-      drawTunerFreq();
+      if (!tunerNotePlaying) {
+        // Only process and draw when note is not playing (listening phase)
+        processTunerData();
+        drawLiveTime('tuner-canvas-time', tunerAnalyser);
+        drawTunerFreq();
+      }
       tunerAnim = requestAnimationFrame(tunerLoop);
     })();
   } catch(e) {
@@ -126,10 +187,24 @@ function stopTuner() {
     tunerStream.getTracks().forEach(t => t.stop());
     tunerStream = null;
   }
-  // Don't close shared audioCtx - just disconnect analyser
+  // Close the separate tuner AudioContext
+  if (tunerAudioCtx && tunerAudioCtx.state !== 'closed') {
+    tunerAudioCtx.close();
+  }
+  tunerAudioCtx = null;
   tunerAnalyser = null;
   tunerActive = false;
+  // Stop alternating mode if active
+  if (tunerAlternating) {
+    tunerAlternating = false;
+    if (tunerAlternatingInterval) {
+      clearInterval(tunerAlternatingInterval);
+      tunerAlternatingInterval = null;
+    }
+  }
+  stopNoteSound();
   document.getElementById('tuner-start-btn').textContent = '▶ Start Tuner';
+  document.getElementById('tuner-play-note-btn').textContent = '🔊 Play Note';
   document.getElementById('tuner-status').textContent = 'Press Start to begin';
   document.getElementById('tuner-status').classList.remove('ok');
   document.getElementById('tuner-live-tag').style.display = 'none';
@@ -155,14 +230,17 @@ function resetTunerDisplay() {
 }
 
 function processTunerData() {
+  // Skip pitch detection while reference note is playing to avoid feedback loop
+  if (tunerNotePlaying) return;
   if (!tunerAnalyser || !tunerTargetFreq) return;
 
   const bufLen = tunerAnalyser.frequencyBinCount;
   const data = new Float32Array(bufLen);
   tunerAnalyser.getFloatTimeDomainData(data);
 
+  const sampleRate = tunerAudioCtx ? tunerAudioCtx.sampleRate : 44100;
   // Detect pitch using autocorrelation
-  const detectedFreq = detectPitchAutoCorr(data, TUNER_SAMPLE_RATE, 50, 2000);
+  const detectedFreq = detectPitchAutoCorr(data, sampleRate, 50, 2000);
   const centsLabel = document.getElementById('tuner-display-cents');
   const indicator = document.getElementById('tuner-indicator');
   const vbar = document.getElementById('tuner-vbar');
@@ -249,65 +327,34 @@ function drawTunerFreq() {
   const ctx = setupCanvas(canvas);
   const {W, H} = dims(canvas);
 
-  const bufLen = tunerAnalyser.frequencyBinCount;
-  const freqData = new Uint8Array(bufLen);
+  const freqData = new Uint8Array(tunerAnalyser.frequencyBinCount);
   tunerAnalyser.getByteFrequencyData(freqData);
-  const sampleRate = TUNER_SAMPLE_RATE;
+  const sampleRate = tunerAudioCtx ? tunerAudioCtx.sampleRate : 44100;
 
   drawGrid(ctx, W, H);
 
-  const maxDisplay = 8000;
-  const MIN_FREQ_LOG = 20;
-  const padX = 40;
-  const padBot = 22;
-  const usableW = W - padX - 10;
-
-  let maxVal = 0;
-  for (let i = 0; i < freqData.length; i++) if (freqData[i] > maxVal) maxVal = freqData[i];
-  if (maxVal === 0) maxVal = 255;
-
-  const numBars = 200;
-  for (let i = 0; i < numBars; i++) {
-    const frac = i / numBars;
-    const freq = MIN_FREQ_LOG * Math.pow(maxDisplay / MIN_FREQ_LOG, frac);
-    const bin = Math.floor((freq / (sampleRate / 2)) * freqData.length);
-    if (bin >= freqData.length) break;
-    const x = padX + frac * usableW;
-    const barH = (freqData[bin] / maxVal) * (H - padBot - 5);
-    const isTargetBin = tunerTargetFreq && Math.abs(freq - tunerTargetFreq) < maxDisplay * 0.03;
-    const hue = isTargetBin ? 140 : 200 + (freqData[bin] / 255) * 60;
-    ctx.fillStyle = isTargetBin ? `rgba(52, 211, 153, .8)` : `hsl(${hue}, 80%, 60%)`;
-    const barW = Math.max(1, (1 / numBars) * usableW - 1);
-    ctx.fillRect(x, H - padBot - barH, barW, barH);
-  }
+  // Use shared spectrum display function
+  drawFreqBars(ctx, W, H, freqData, sampleRate);
 
   // Draw target marker if set
-  if (tunerTargetFreq && tunerTargetFreq <= maxDisplay) {
-    const targetFrac = Math.log(tunerTargetFreq / MIN_FREQ_LOG) / Math.log(maxDisplay / MIN_FREQ_LOG);
-    const targetX = padX + targetFrac * usableW;
-    ctx.strokeStyle = '#34d399';
-    ctx.lineWidth = 2;
-    ctx.setLineDash([4, 3]);
-    ctx.beginPath();
-    ctx.moveTo(targetX, 0);
-    ctx.lineTo(targetX, H - padBot);
-    ctx.stroke();
-    ctx.setLineDash([]);
+  if (tunerTargetFreq) {
+    const maxDisplay = getSpectrumRange();
+    const MIN_FREQ_LOG = 10;
+    const padX = 40;
+    const padBot = 22;
+    const usableW = W - padX - 10;
+
+    if (tunerTargetFreq <= maxDisplay) {
+      const targetFrac = Math.log(tunerTargetFreq / MIN_FREQ_LOG) / Math.log(maxDisplay / MIN_FREQ_LOG);
+      const targetX = padX + targetFrac * usableW;
+      ctx.strokeStyle = '#34d399';
+      ctx.lineWidth = 2;
+      ctx.setLineDash([4, 3]);
+      ctx.beginPath();
+      ctx.moveTo(targetX, 0);
+      ctx.lineTo(targetX, H - padBot);
+      ctx.stroke();
+      ctx.setLineDash([]);
+    }
   }
-
-  ctx.strokeStyle = '#2e3250';
-  ctx.lineWidth = 1;
-  ctx.beginPath();
-  ctx.moveTo(padX, H - padBot);
-  ctx.lineTo(W, H - padBot);
-  ctx.stroke();
-
-  ctx.fillStyle = '#64748b';
-  ctx.font = '10px Segoe UI';
-  ctx.textAlign = 'center';
-  [50, 100, 200, 500, 1000, 2000, 4000, 8000].forEach(f => {
-    if (f > maxDisplay) return;
-    const x = padX + (Math.log(f / MIN_FREQ_LOG) / Math.log(maxDisplay / MIN_FREQ_LOG)) * usableW;
-    ctx.fillText(f >= 1000 ? `${f/1000}k` : f, x, H - 5);
-  });
 }

--- a/javascript/tuner.js
+++ b/javascript/tuner.js
@@ -14,6 +14,8 @@ const TUNER_SAMPLE_RATE = 44100;
 function initTuner() {
   const sel = document.getElementById('tuner-note-select');
   NOTE_NAMES.forEach(n => { const o=document.createElement('option'); o.value=n; o.textContent=n; sel.appendChild(o); });
+  // Default to Middle C
+  setTunerMiddleC();
 }
 
 function onTunerNoteSelect() {
@@ -334,11 +336,11 @@ function drawTunerFreq() {
   drawGrid(ctx, W, H);
 
   // Use shared spectrum display function
-  drawFreqBars(ctx, W, H, freqData, sampleRate);
+  drawFreqBars(ctx, W, H, freqData, sampleRate, 'tuner-canvas-freq');
 
   // Draw target marker if set
   if (tunerTargetFreq) {
-    const maxDisplay = getSpectrumRange();
+    const maxDisplay = 32000; // Fixed max display (spectrum range selector removed)
     const MIN_FREQ_LOG = 10;
     const padX = 40;
     const padBot = 22;

--- a/styles.css
+++ b/styles.css
@@ -1,0 +1,209 @@
+*, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+:root {
+  --bg: #0f1117; --card: #1a1d27; --card2: #21253a; --border: #2e3250;
+  --accent: #6c8aff; --accent2: #a78bfa; --green: #34d399; --red: #f87171;
+  --yellow: #fbbf24; --text: #e2e8f0; --muted: #64748b;
+}
+body { background: var(--bg); color: var(--text); font-family: 'Segoe UI', system-ui, sans-serif; min-height: 100vh; padding: 0 0 40px; }
+
+/* Tooltip styles */
+[title] { position: relative; }
+[title]:hover::after {
+  content: attr(title);
+  position: absolute;
+  bottom: 100%;
+  left: 50%;
+  transform: translateX(-50%);
+  background: var(--card2);
+  color: var(--text);
+  padding: 4px 8px;
+  border-radius: 4px;
+  font-size: 0.7rem;
+  white-space: nowrap;
+  z-index: 100;
+  pointer-events: none;
+  margin-bottom: 4px;
+}
+
+/* Card info tooltip */
+.card[data-info] { position: relative; }
+.card[data-info]:hover::after {
+  content: attr(data-info);
+  position: absolute;
+  top: -8px;
+  right: -8px;
+  background: var(--card2);
+  color: var(--text);
+  padding: 8px 12px;
+  border-radius: 6px;
+  font-size: 0.7rem;
+  white-space: normal;
+  max-width: 250px;
+  z-index: 100;
+  pointer-events: none;
+  box-shadow: 0 4px 12px rgba(0,0,0,0.4);
+  border: 1px solid var(--border);
+}
+
+/* Info icon */
+.info-icon {
+  display: inline-block;
+  font-size: 0.7rem;
+  color: var(--muted);
+  cursor: help;
+  margin-left: 4px;
+  font-weight: normal;
+}
+.info-icon:hover {
+  color: var(--accent);
+}
+
+/* Card h2 with info icon */
+.card h2 { display: flex; align-items: center; }
+
+/* ── Header ── */
+header { text-align: center; padding: 24px 20px 0; }
+header h1 { font-size: 1.8rem; font-weight: 800; background: linear-gradient(135deg, var(--accent), var(--accent2)); -webkit-background-clip: text; -webkit-text-fill-color: transparent; background-clip: text; }
+header p { color: var(--muted); font-size: 0.85rem; margin-top: 4px; }
+
+/* ── Tabs ── */
+.tab-bar { display: flex; gap: 0; justify-content: center; margin: 20px 20px 0; border-bottom: 2px solid var(--border); }
+.tab { padding: 10px 24px; font-size: 0.88rem; font-weight: 700; cursor: pointer; border: none; background: none; color: var(--muted); border-bottom: 3px solid transparent; margin-bottom: -2px; transition: color 0.2s, border-color 0.2s; }
+.tab:hover { color: var(--text); }
+.tab.active { color: var(--accent); border-bottom-color: var(--accent); }
+
+/* ── Pages ── */
+.page { display: none; padding: 20px; max-width: 1400px; margin: 0 auto; }
+.page.active { display: block; }
+
+/* ── Card ── */
+.card { background: var(--card); border: 1px solid var(--border); border-radius: 16px; padding: 20px; }
+.card + .card { margin-top: 16px; }
+.card h2 { font-size: 0.75rem; font-weight: 700; text-transform: uppercase; letter-spacing: 0.1em; color: var(--accent); margin-bottom: 14px; }
+
+/* ── Layout helpers ── */
+.cols { display: grid; gap: 20px; }
+.cols-2 { grid-template-columns: 1fr 1fr; }
+.cols-left-right { grid-template-columns: 340px 1fr; }
+@media(max-width:960px){ .cols-left-right,.cols-2 { grid-template-columns:1fr; } }
+.flex-col { display:flex; flex-direction:column; gap:16px; }
+.flex-row { display:flex; gap:10px; align-items:center; flex-wrap:wrap; }
+
+/* ── Buttons ── */
+.btn { padding: 10px 16px; border: none; border-radius: 12px; font-size: 0.87rem; font-weight: 700; cursor: pointer; transition: opacity .15s, transform .1s; }
+.btn:active { transform: scale(.97); }
+.btn:disabled { opacity: .38; cursor: default; }
+.btn-primary  { background: linear-gradient(135deg, var(--accent), var(--accent2)); color: #fff; }
+.btn-stop     { background: var(--card2); border: 1.5px solid var(--border); color: var(--text); }
+.btn-rec      { background: linear-gradient(135deg, #ef4444, #f97316); color: #fff; }
+.btn-green    { background: linear-gradient(135deg, #34d399, #059669); color: #fff; }
+.btn-sm       { padding: 5px 12px; font-size: 0.78rem; border-radius: 8px; }
+.btn-rec.recording { animation: pulse 1s infinite; }
+@keyframes pulse { 0%,100%{opacity:1} 50%{opacity:.55} }
+
+/* ── Preset buttons ── */
+.presets { display: flex; gap: 6px; flex-wrap: wrap; }
+.preset-btn { flex:1; min-width:68px; padding:7px 8px; border:1.5px solid var(--border); border-radius:10px; background:var(--card2); color:var(--text); font-size:.78rem; font-weight:600; cursor:pointer; transition:border-color .2s,background .2s; }
+.preset-btn:hover { border-color:var(--accent); background:#2a2f4a; }
+.preset-btn.active { border-color:var(--accent); background:rgba(108,138,255,.15); color:var(--accent); }
+.noise-btn.active  { border-color:var(--yellow); background:rgba(251,191,36,.12); color:var(--yellow); }
+
+/* ── Form elements ── */
+input[type="number"], input[type="text"], select.styled {
+  background: var(--card2); border: 1.5px solid var(--border); border-radius: 8px;
+  color: var(--text); padding: 5px 9px; font-size: 0.85rem;
+}
+input[type="number"]:focus, input[type="text"]:focus, select.styled:focus { outline: none; border-color: var(--accent); }
+input[type="range"] { accent-color: var(--accent); cursor: pointer; }
+input[type="checkbox"] { accent-color: var(--accent); cursor: pointer; width:16px; height:16px; }
+
+.unit-btn { padding:4px 10px; border:1.5px solid var(--border); border-radius:6px; background:var(--card2); color:var(--muted); font-size:.75rem; font-weight:600; cursor:pointer; }
+.unit-btn.active { border-color:var(--accent); color:var(--accent); background:rgba(108,138,255,.1); }
+
+label.small { font-size:.8rem; color:var(--muted); white-space:nowrap; }
+
+/* ── Volume row ── */
+.vol-row { display:flex; align-items:center; gap:10px; }
+.vol-row input[type="range"] { flex:1; }
+.vol-row span { font-size:.8rem; min-width:36px; text-align:right; }
+
+/* ── Freq slider (page 1) ── */
+.freq-slider-wrap { margin-top: 10px; }
+.freq-slider-header { display:flex; justify-content:space-between; align-items:center; margin-bottom:8px; }
+.freq-slider-val { font-size:1.3rem; font-weight:800; color:var(--accent); }
+.freq-slider-sub { font-size:.75rem; color:var(--muted); margin-top:2px; }
+#single-freq-range { width:100%; height:8px; }
+
+/* ── Harmonics (page 2) ── */
+.harmonics-header { display:grid; grid-template-columns:22px 1fr 80px 36px; gap:5px; padding:0 2px; margin-bottom:6px; }
+.harmonics-header span { font-size:.68rem; color:var(--muted); text-transform:uppercase; letter-spacing:.05em; }
+.harmonic-row { display:grid; grid-template-columns:22px 1fr 80px 36px; gap:5px; align-items:center; margin-bottom:4px; }
+.harmonic-row .idx { font-size:.7rem; color:var(--muted); text-align:center; }
+.freq-input-wrap { position:relative; display:flex; align-items:center; }
+.freq-input-wrap input[type="text"] { padding:4px 30px 4px 7px; width:100%; font-size:.82rem; }
+.freq-input-wrap input.active-freq { border-color:var(--accent); }
+.freq-unit-toggle { position:absolute; right:4px; font-size:.65rem; color:var(--muted); cursor:pointer; padding:2px 3px; border-radius:4px; background:var(--border); user-select:none; }
+.freq-unit-toggle:hover { color:var(--accent); }
+.amp-val { font-size:.75rem; color:var(--muted); text-align:right; }
+.harmonics-scroll { max-height:480px; overflow-y:auto; padding-right:4px; }
+.harmonics-scroll::-webkit-scrollbar { width:4px; }
+.harmonics-scroll::-webkit-scrollbar-thumb { background:var(--border); border-radius:4px; }
+
+/* ── Graphs ── */
+canvas { width:100%; height:200px; display:block; border-radius:10px; background:#0a0c14; }
+canvas.short { height:160px; }
+.graph-wrap { position:relative; margin-bottom:16px; }
+.graph-wrap:last-child { margin-bottom:0; }
+.graph-wrap h3 { font-size:.72rem; font-weight:700; text-transform:uppercase; letter-spacing:.08em; color:var(--muted); margin-bottom:8px; }
+.tag { display:inline-block; font-size:.65rem; font-weight:700; padding:1px 7px; border-radius:20px; margin-left:6px; vertical-align:middle; }
+.tag-gen { background:rgba(108,138,255,.2); color:var(--accent); }
+.tag-rec { background:rgba(248,113,113,.2); color:var(--red); }
+.tag-live { background:rgba(34,197,94,.2); color:var(--green); animation:pulse 1.5s infinite; }
+@keyframes pulse { 0%,100%{opacity:1;} 50%{opacity:0.6;} }
+.no-data { position:absolute; inset:0; display:flex; align-items:center; justify-content:center; color:var(--muted); font-size:.82rem; pointer-events:none; border-radius:10px; }
+
+/* ── Rec status ── */
+.rec-status { font-size:.82rem; color:var(--red); min-height:20px; margin-top:8px; text-align:center; }
+.rec-status.ok { color:var(--green); }
+
+/* ── Note picker ── */
+.note-freq-display { font-size:.8rem; color:var(--accent); min-width:72px; }
+
+/* ── Tag indicator ── */
+.noise-indicator { display:inline-block; font-size:.65rem; font-weight:700; padding:1px 7px; border-radius:20px; margin-left:6px; vertical-align:middle; background:rgba(251,191,36,.15); color:var(--yellow); }
+
+/* ── Collapsible ── */
+.collapsible-header { display:flex; justify-content:space-between; align-items:center; cursor:pointer; user-select:none; }
+.collapsible-header:hover h2 { color:var(--accent2); }
+.collapsible-toggle { font-size:.7rem; color:var(--muted); transition:transform .2s; }
+.collapsible-content { overflow:hidden; transition:max-height .3s ease-out; }
+.collapsible-content.collapsed { max-height:0 !important; }
+
+/* ── Tuner ── */
+.tuner-note { font-size:2.5rem; font-weight:800; }
+.tuner-freq { font-size:1rem; color:var(--muted); }
+.tuner-cents { font-size:1.2rem; font-weight:700; }
+.tuner-indicator { font-size:.85rem; font-weight:700; padding:4px 14px; border-radius:20px; }
+.tuner-indicator.high { background:rgba(248,113,113,.2); color:var(--red); }
+.tuner-indicator.low { background:rgba(108,138,255,.2); color:var(--accent); }
+.tuner-indicator.in-tune { background:rgba(34,197,94,.2); color:var(--green); }
+.tuner-off { background:rgba(100,116,139,.2); color:var(--muted); }
+
+/* ── Metronome ── */
+.metro-visual-row { display:grid; grid-template-columns:1fr 1fr; gap:20px; }
+@media(max-width:800px){ .metro-visual-row { grid-template-columns:1fr; } }
+.metro-pendulum-wrap { width:140px; height:200px; margin:0 auto; position:relative; background:var(--card2); border-radius:8px; overflow:hidden; }
+.metro-pendulum { position:absolute; width:6px; height:140px; background:linear-gradient(to top, var(--accent), var(--accent2)); left:50%; bottom:20px; transform-origin:bottom center; border-radius:3px; }
+.metro-pivot { position:absolute; bottom:16px; left:50%; transform:translateX(-50%); width:16px; height:16px; background:var(--border); border-radius:50%; }
+.metro-weight { position:absolute; top:8px; left:50%; transform:translateX(-50%); width:20px; height:20px; background:var(--accent); border-radius:50%; }
+.metro-level-wrap { width:60px; height:200px; margin:0 auto; background:var(--card2); border-radius:8px; position:relative; overflow:hidden; display:flex; flex-direction:column-reverse; padding:8px 6px; gap:3px; }
+.metro-led { flex:1; border-radius:2px; background:var(--border); opacity:0.3; transition:opacity .05s, background .05s; }
+.metro-led.on.green { background:var(--green); opacity:1; box-shadow:0 0 6px var(--green); }
+.metro-led.on.yellow { background:#fbbf24; opacity:1; box-shadow:0 0 6px #fbbf24; }
+.metro-led.on.red { background:#ef4444; opacity:1; box-shadow:0 0 6px #ef4444; }
+
+/* ── Synth Pad ── */
+.pad-key-grid { display:grid; grid-template-columns:repeat(4,1fr); gap:8px; margin-bottom:12px; }
+.pad-key-btn { padding:12px 8px; border:1.5px solid var(--border); border-radius:10px; background:var(--card2); color:var(--text); font-size:1.1rem; font-weight:700; cursor:pointer; transition:border-color .2s,background .2s; }
+.pad-key-btn:hover { border-color:var(--accent); background:#2a2f4a; }
+.pad-key-btn.active { border-color:var(--accent); background:rgba(108,138,255,.2); color:var(--accent); }


### PR DESCRIPTION
## Summary
- Segregate CSS from HTML into separate `styles.css` file
- Add min power selector (-10, -20, -40, -80 dB) to each spectrum analyzer card
- Sync min power setting globally across all pages (Signal Generator, Recorder, Tuner)
- Set default min power to -10 dB with tick marks at bottom of y-axis and right end of x-axis
- Move master volume inline with title on right side of header
- Set default tuner target note to Middle C
- Update AGENTS.md to document separate source file structure

## Changes
- `styles.css` - New file containing all CSS styles
- `index.html` - Updated to link external CSS, updated header layout, added min power selectors
- `javascript/drawing.js` - Updated axis drawing functions with new tick marks
- `javascript/shared.js` - Added global power range setting synced across pages
- `javascript/tuner.js` - Set default target note to Middle C
- `AGENTS.md` - Document that each language must be kept in separate source files