### PR TITLE
Fix favicon not displaying

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,6 +4,7 @@
   <meta charset="UTF-8"/>
   <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
   <title>Audio Tools — Signal Generator</title>
+  <link rel="icon" type="image/x-icon" href="icons/favicon.ico"/>
   <link rel="stylesheet" href="styles.css"/>
 </head>
 <body>


### PR DESCRIPTION
## Summary
- Add missing favicon link to HTML head section
- Point to existing `icons/favicon.ico` file

## Changes
- `index.html` - Added `<link rel="icon" type="image/x-icon" href="icons/favicon.ico"/>` to head section